### PR TITLE
Fix tests for latest rspec-puppet, pin puppet-lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 # Verify this with: http://lint.travis-ci.org/
 language: ruby
-# Delete dependency locks for matrix builds.
+bundler_args: --without development system_tests
 before_install: rm Gemfile.lock || true
 script: bundle exec rake test
 rvm:

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source 'https://rubygems.org'
 gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.6.0'
 
 gem 'rake'
-gem 'puppet-lint'
+gem 'puppet-lint', '~> 1.0.1' # Until they fix regression for ignore_paths
 gem 'serverspec'
 gem 'rspec-puppet'
 gem 'rspec-system-puppet'

--- a/Gemfile
+++ b/Gemfile
@@ -5,14 +5,21 @@ source 'https://rubygems.org'
 
 gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.6.0'
 
-gem 'rake'
-gem 'puppet-lint', '~> 1.0.1' # Until they fix regression for ignore_paths
-gem 'serverspec'
-gem 'rspec-puppet'
-gem 'rspec-system-puppet'
-gem 'rspec-system-serverspec'
-gem 'puppetlabs_spec_helper'
+group :development, :test do
+  gem 'rake'
+  gem 'puppet-lint', '~> 1.0.1' # Until they fix regression for ignore_paths
+  gem 'rspec-puppet'
+  gem 'puppetlabs_spec_helper'
 
-# Needed since puppet 2.7 doesn't include hiera
-gem 'hiera' if ENV['PUPPET_VERSION'] =~ /2.7/
-gem 'hiera-puppet' if ENV['PUPPET_VERSION'] =~ /2.7/
+  # Needed since puppet 2.7 doesn't include hiera
+  if ENV['PUPPET_VERSION'] =~ /2.7/
+    gem 'hiera'
+    gem 'hiera-puppet'
+  end
+end
+
+group :system_tests do
+  gem 'serverspec'
+  gem 'rspec-system-puppet'
+  gem 'rspec-system-serverspec'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,12 @@
 require 'puppet-lint/tasks/puppet-lint'
 require 'puppetlabs_spec_helper/rake_tasks'
-require 'rspec-system/rake_task'
+
+# These gems aren't always present,
+# for example on Travis without system_tests
+begin
+  require 'rspec-system/rake_task'
+rescue LoadError
+end
 
 PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
 PuppetLint.configuration.fail_on_warnings = true
@@ -10,6 +16,7 @@ exclude_paths = [
   "vendor/**/*",
   "spec/**/*",
 ]
+
 PuppetLint.configuration.ignore_paths = exclude_paths
 PuppetSyntax.exclude_paths = exclude_paths
 

--- a/Rakefile
+++ b/Rakefile
@@ -11,6 +11,7 @@ exclude_paths = [
   "spec/**/*",
 ]
 PuppetLint.configuration.ignore_paths = exclude_paths
+PuppetSyntax.exclude_paths = exclude_paths
 
 desc "Run lint and spec tests."
 task :test => [

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe 'varnish::config' do
   let(:facts) {{
     :osfamily => 'Debian',
+    :lsbdistid => 'Ubuntu',
     :lsbdistcodename => 'precise',
   }}
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -7,6 +7,7 @@ describe 'varnish' do
         let(:params) {{ }}
         let(:facts) {{
           :osfamily => osfamily,
+          :lsbdistid => 'Ubuntu',
           :lsbdistcodename => 'precise',
         }}
 
@@ -26,7 +27,7 @@ describe 'varnish' do
         :operatingsystem => 'Nexenta',
       }}
 
-      it { expect { should }.to raise_error(Puppet::Error, /Nexenta not supported/) }
+      it { expect { should raise_error(Puppet::Error, /Nexenta not supported/) } }
     end
   end
   context 'invalid parameter' do
@@ -34,7 +35,7 @@ describe 'varnish' do
       let :params do
         { :foo => 'bar' }
       end
-      it { expect { should }.to raise_error(Puppet::Error, /Invalid parameter foo/) }
+      it { expect { should raise_error(Puppet::Error, /Invalid parameter foo/) } }
     end
   end
 end

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe 'varnish', :type => :class do
   let(:facts) {{
     :osfamily => 'Debian',
+    :lsbdistid => 'Ubuntu',
     :lsbdistcodename => 'precise',
   }}
 

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -4,6 +4,7 @@ describe 'varnish', :type => :class do
   describe 'varnish::repo class on Debian' do
     let(:facts) {{
       :osfamily => 'Debian',
+      :lsbdistid => 'Ubuntu',
       :lsbdistcodename => 'precise',
     }}
 
@@ -25,7 +26,7 @@ describe 'varnish', :type => :class do
       let(:params) {{
         :apt_location => 'http://example.com/debian',
         :apt_repos => 'main',
-        :apt_key => 'XXXXXXX',
+        :apt_key => 'FFFFFFFF',
         :apt_key_source => 'http://example.com/foo.txt',
         :apt_include_src => false,
       }}
@@ -34,7 +35,7 @@ describe 'varnish', :type => :class do
         'location' => 'http://example.com/debian',
         'release' => 'precise',
         'repos' => 'main',
-        'key' => 'XXXXXXX',
+        'key' => 'FFFFFFFF',
         'key_source' => 'http://example.com/foo.txt',
         'include_src' => false,
         })

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -4,6 +4,7 @@ describe 'varnish::service' do
   describe 'varnish::service class on Debian' do
     let(:facts) {{
       :osfamily => 'Debian',
+      :lsbdistid => 'Ubuntu',
     }}
 
     it { should contain_service('varnish').with({

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -7,6 +7,7 @@ describe 'varnish::instance', :type => :define do
 
   let(:facts) {{
     :osfamily => 'Debian',
+    :lsbdistid => 'Ubuntu',
     :lsbdistcodename => 'precise',
   }}
 
@@ -603,33 +604,25 @@ describe 'varnish::instance', :type => :define do
       let :params do
         { :varnishlog => 'foo' }
       end
-      it { expect { should }.to raise_error(Puppet::Error,
-                                            /"foo" is not a boolean/)
-      }
+      it { expect { should raise_error(Puppet::Error, /foo is not a boolean/) } }
     end
     context "when varnishncsa is not a boolean" do
       let :params do
         { :varnishlog => 'foo' }
       end
-      it { expect { should }.to raise_error(Puppet::Error,
-                                            /"foo" is not a boolean/)
-      }
+      it { expect { should raise_error(Puppet::Error, /foo is not a boolean/) } }
     end
     context "with unsupported init_method" do
       let :params do
         { :init_method => 'foo' }
       end
-      it { expect { should }.to raise_error(
-        Puppet::Error, /Varnish::Instance\[default\]: Unsupported init => foo/)
-      }
+      it { expect { should raise_error(Puppet::Error, /Varnish::Instance\[default\]: Unsupported init => foo/) } }
     end
     context "with unsupported ensure" do
       let :params do
         { :ensure => 'foo' }
       end
-      it { expect { should }.to raise_error(
-        Puppet::Error, /Varnish::Instance\[default\]: Unsupported ensure => foo/)
-      }
+      it { expect { should raise_error(Puppet::Error, /Varnish::Instance\[default\]: Unsupported ensure => foo/) } }
     end
   end
 end

--- a/spec/defines/vmod_spec.rb
+++ b/spec/defines/vmod_spec.rb
@@ -7,6 +7,7 @@ describe 'varnish::vmod', :type => :define do
 
   let(:facts) {{
     :osfamily => 'Debian',
+    :lsbdistid => 'Ubuntu',
     :lsbdistcodename => 'precise',
   }}
 


### PR DESCRIPTION
* The latest rspec-puppet (2.0.0) makes a breaking change to how failure checks are performed, expect { should }.to raise_error(...) had to be replaced with expect { should raise_error(...) }.
* PuppetLint.configuration.ignore_paths does not work in 1.1.0.