### PR TITLE
Unpin apt module

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,6 +3,5 @@ fixtures:
     stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
     apt:
       repo: "git://github.com/puppetlabs/puppetlabs-apt.git"
-      ref: "1.4.0"
   symlinks:
     varnish: "#{source_dir}"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2015-02-24 Release 0.0.5
+- Dont pin puppetlabs/apt at 1.4.0
+
 2014-09-17 Release 0.0.4
 - Add support for changing logdirs
 - Add support for changing ncsa log format

--- a/Modulefile
+++ b/Modulefile
@@ -8,4 +8,4 @@ description   'Varnish module for Puppet'
 project_page  'https://github.com/chartbeat-labs/puppet-varnish'
 
 dependency 'puppetlabs/stdlib', '>= 3.0.0'
-dependency 'puppetlabs/apt', '= 1.4.0'
+dependency 'puppetlabs/apt', '>= 1.4.0'


### PR DESCRIPTION
We had previously pinned the apt module due to some incompatibilities. These have been resolved.