### PR TITLE
Remove 1 8 7 add 2 0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ bundler_args: --without development system_tests
 before_install: rm Gemfile.lock || true
 script: bundle exec rake test
 rvm:
-  - 1.8.7
   - 1.9.3
+  - 2.0.0
 env:
   matrix:
   - PUPPET_VERSION="~> 2.7.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,7 @@ env:
   matrix:
   - PUPPET_VERSION="~> 2.7.0"
   - PUPPET_VERSION="~> 3.1.0"
-  - PUPPET_VERSION="~> 3.2.0"
   - PUPPET_VERSION="~> 3.3.0"
-  - PUPPET_VERSION="~> 3.4.0"
-  - PUPPET_VERSION="~> 3.6.0"
   - PUPPET_VERSION="~> 3.7.0"
 # Only notify for failed builds.
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,17 @@ rvm:
   - 1.9.3
   - 2.0.0
 env:
-  matrix:
   - PUPPET_VERSION="~> 2.7.0"
   - PUPPET_VERSION="~> 3.1.0"
   - PUPPET_VERSION="~> 3.3.0"
   - PUPPET_VERSION="~> 3.7.0"
+matrix:
+  exclude:
+  - rvm: 2.0.0
+    env: PUPPET_VERSION="~> 2.7.0"
+  - rvm: 2.0.0
+    env: PUPPET_VERSION="~> 3.1.0"
+
 # Only notify for failed builds.
 notifications:
   email:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+2015-03-05 Release 1.0.0
+- Drop support for ruby 1.8.7
+- Add support for ruby 2.0.0
+- Bump puppetlabs/apt, puppetlabs/stdlib deps
+
 2015-02-24 Release 0.0.5
 - Dont pin puppetlabs/apt at 1.4.0
 - Add tests for puppet 3.7

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "chartbeat-varnish",
-  "version": "0.0.5",
+  "version": "1.0.0",
   "author": "chartbeat",
   "summary": "Module to manage the Varnish Web Accelerator",
   "license": "MIT",
@@ -9,7 +9,7 @@
   "issues_url": "https://github.com/chartbeat-labs/puppet-varnish/issues",
   "description": "Varnish module for Puppet",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 3.0.0"},
-    {"name":"puppetlabs/apt","version_requirement":">= 1.4.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.0.0"},
+    {"name":"puppetlabs/apt","version_requirement":">= 1.7.0"}
   ]
 }


### PR DESCRIPTION
This removes support for 1.8.7 and adds support for 2.0.0. Needed to exclude a few versions from the matrix build since there are some issues with earlier puppet versions and ruby 2.0. Since this seems to break compat with earlier puppet versions, bump a major release.