### PR TITLE
Update puppetlabs/apt dependency

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,6 +5,6 @@ fixtures:
       ref: "4.1.0"
     apt:
       repo: "puppetlabs/apt"
-      ref: "1.7.0"
+      ref: "2.1.0"
   symlinks:
     varnish: "#{source_dir}"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2015-07-23 Release 1.1.0
+- Support puppetlabs/apt >=2.0.0
+- Not backwards compat with puppetlabs/apt <2.0.0
+
 2015-03-09 Release 1.0.1
 - Add groups to the Gemfile
 - Remove rspec-system-puppet in favor of the puppetlabs supported beaker

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -10,8 +10,13 @@ class varnish::repo {
     location    => $::varnish::apt_location,
     release     => $::lsbdistcodename,
     repos       => $::varnish::apt_repos,
-    key         => $::varnish::apt_key,
-    key_source  => $::varnish::apt_key_source,
-    include_src => $::varnish::apt_include_src,
+    key         => {
+      'id'      => $::varnish::apt_key,
+      'source'  => $::varnish::apt_key_source,
+    },
+    include => {
+      'deb' => 'true',
+      'src' => $::varnish::apt_include_src,
+    },
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "chartbeat-varnish",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "author": "chartbeat",
   "summary": "Module to manage the Varnish Web Accelerator",
   "license": "MIT",
@@ -15,7 +15,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=1.7.0 <2.0.0"
+      "version_requirement": ">=2.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -15,9 +15,9 @@ describe 'varnish', :type => :class do
           'location' => 'http://repo.varnish-cache.org/debian/',
           'release' => 'precise',
           'repos' => 'varnish-3.0',
-          'key' => 'C4DEFFEB',
-          'key_source' => 'http://repo.varnish-cache.org/debian/GPG-key.txt',
-          'include_src' => true,
+          'key' => { 'id' => 'C4DEFFEB', 'source' => 'http://repo.varnish-cache.org/debian/GPG-key.txt', },
+          'include' => { 'deb' => true, 'src' => 'true' },
+
         })
       }
     end
@@ -35,9 +35,8 @@ describe 'varnish', :type => :class do
         'location' => 'http://example.com/debian',
         'release' => 'precise',
         'repos' => 'main',
-        'key' => 'FFFFFFFF',
-        'key_source' => 'http://example.com/foo.txt',
-        'include_src' => false,
+        'key' => { 'id' => 'FFFFFFFF', 'source' => 'http://example.com/foo.txt', },
+        'include' => { 'deb' => true, 'src' => 'false' },
         })
       }
     end


### PR DESCRIPTION
 * Update to >=2.0.0 puppetlabs/apt
 * Breaks backwards compat with <2.0.0
 * Will probably kill varnish::repo and varnish::vmods in future.